### PR TITLE
Sprk 2573 xapi statements 

### DIFF
--- a/lrs/managers/StatementManager.py
+++ b/lrs/managers/StatementManager.py
@@ -77,7 +77,8 @@ class StatementManager():
         try:
             stmt = Statement.objects.create(**self.data)
         except IntegrityError as e:
-            if e.message.startswith('duplicate key value violates unique constraint "lrs_statement_statement_id_key"'):
+            print('IM HEREEEEE')
+            if str(e).startswith('duplicate key value violates unique constraint "lrs_statement_statement_id_key"'):
                 err_msg = "A statement with ID %s already exists" % self.data.get('statement_id')
                 raise ParamConflict(err_msg)
             raise

--- a/lrs/managers/StatementManager.py
+++ b/lrs/managers/StatementManager.py
@@ -77,7 +77,6 @@ class StatementManager():
         try:
             stmt = Statement.objects.create(**self.data)
         except IntegrityError as e:
-            print('IM HEREEEEE')
             if str(e).startswith('duplicate key value violates unique constraint "lrs_statement_statement_id_key"'):
                 err_msg = "A statement with ID %s already exists" % self.data.get('statement_id')
                 raise ParamConflict(err_msg)


### PR DESCRIPTION
fix E2E test with 500 status code error
test_spark_can_handle_two_simultaneous_xapi_statements_with_same_id